### PR TITLE
Add domain and feature tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,6 +11,9 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Domain">
+            <directory>tests/Domain</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/tests/Domain/Auth/EmailTest.php
+++ b/tests/Domain/Auth/EmailTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Domain\Auth;
+
+use App\Domain\Auth\ValueObjects\Email;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class EmailTest extends TestCase
+{
+    public function test_it_accepts_valid_email(): void
+    {
+        $email = new Email('test@example.com');
+        $this->assertSame('test@example.com', $email->getValue());
+    }
+
+    public function test_it_rejects_empty_email(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Email('');
+    }
+
+    public function test_it_rejects_invalid_format(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Email('invalid');
+    }
+
+    public function test_it_rejects_too_long_email(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Email(str_repeat('a', 256).'@example.com');
+    }
+}
+

--- a/tests/Domain/Auth/PasswordTest.php
+++ b/tests/Domain/Auth/PasswordTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Domain\Auth;
+
+use App\Domain\Auth\ValueObjects\Password;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class PasswordTest extends TestCase
+{
+    public function test_it_accepts_valid_password(): void
+    {
+        $password = new Password('secret123');
+        $this->assertSame('secret123', $password->getValue());
+    }
+
+    public function test_it_rejects_empty_password(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Password('');
+    }
+
+    public function test_it_rejects_short_password(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Password('short');
+    }
+
+    public function test_hash_and_verify_password(): void
+    {
+        $password = new Password('secret123');
+        $hash = $password->hash();
+        $this->assertTrue((new Password('secret123'))->verify($hash));
+        $this->assertFalse((new Password('wrongpass'))->verify($hash));
+    }
+}
+

--- a/tests/Domain/Blog/BlogServiceTest.php
+++ b/tests/Domain/Blog/BlogServiceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Domain\Blog;
+
+use App\Domain\Blog\Services\BlogService;
+use App\Domain\Blog\Repositories\BlogRepositoryInterface;
+use App\Domain\Blog\Repositories\CategoryRepositoryInterface;
+use App\Domain\Blog\Repositories\TagRepositoryInterface;
+use App\Domain\Blog\Exceptions\CategoryNotFoundException;
+use App\Domain\Blog\Exceptions\BlogNotFoundException;
+use App\Domain\Blog\Entities\Category;
+use App\Domain\Auth\Entities\User;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class BlogServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_create_blog_throws_exception_when_category_not_found(): void
+    {
+        $blogRepo = Mockery::mock(BlogRepositoryInterface::class);
+        $categoryRepo = Mockery::mock(CategoryRepositoryInterface::class);
+        $tagRepo = Mockery::mock(TagRepositoryInterface::class);
+
+        $categoryRepo->shouldReceive('findById')->with(1)->andReturn(null);
+
+        $service = new BlogService($blogRepo, $categoryRepo, $tagRepo);
+
+        $user = new User(['name' => 'John Doe', 'email' => 'john@example.com', 'password' => 'password123']);
+
+        $this->expectException(CategoryNotFoundException::class);
+
+        $service->createBlog([
+            'title' => 'Test Blog',
+            'content' => 'Content',
+            'category_id' => 1
+        ], $user);
+    }
+
+    public function test_get_blog_by_slug_throws_exception_when_not_found(): void
+    {
+        $blogRepo = Mockery::mock(BlogRepositoryInterface::class);
+        $categoryRepo = Mockery::mock(CategoryRepositoryInterface::class);
+        $tagRepo = Mockery::mock(TagRepositoryInterface::class);
+
+        $blogRepo->shouldReceive('findBySlug')->with('missing-blog')->andReturn(null);
+
+        $service = new BlogService($blogRepo, $categoryRepo, $tagRepo);
+
+        $this->expectException(BlogNotFoundException::class);
+        $service->getBlogBySlug('missing-blog');
+    }
+
+    public function test_get_published_blogs_returns_data(): void
+    {
+        $blogRepo = Mockery::mock(BlogRepositoryInterface::class);
+        $categoryRepo = Mockery::mock(CategoryRepositoryInterface::class);
+        $tagRepo = Mockery::mock(TagRepositoryInterface::class);
+
+        $expected = ['blogs' => [], 'pagination' => ['current_page' => 1, 'per_page' => 10, 'total' => 0]];
+        $blogRepo->shouldReceive('findPublished')->with(1, 10)->andReturn($expected);
+
+        $service = new BlogService($blogRepo, $categoryRepo, $tagRepo);
+
+        $result = $service->getPublishedBlogs();
+        $this->assertSame($expected, $result);
+    }
+}
+

--- a/tests/Feature/AuthApiTest.php
+++ b/tests/Feature/AuthApiTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Infrastructure\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuthApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_register(): void
+    {
+        $response = $this->postJson('/api/register', [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'password' => 'password123',
+        ]);
+
+        $response->assertStatus(201)
+                 ->assertJsonStructure([
+                     'user' => ['id', 'name', 'email'],
+                     'token',
+                 ]);
+
+        $this->assertDatabaseHas('users', ['email' => 'john@example.com']);
+    }
+
+    public function test_user_can_login(): void
+    {
+        User::factory()->create([
+            'email' => 'john@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $response = $this->postJson('/api/login', [
+            'email' => 'john@example.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     'user' => ['id', 'name', 'email'],
+                     'token',
+                 ]);
+    }
+}
+

--- a/tests/Feature/BlogApiTest.php
+++ b/tests/Feature/BlogApiTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Infrastructure\Models\Blog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BlogApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_list_published_blogs(): void
+    {
+        Blog::factory()->published()->count(3)->create();
+
+        $response = $this->getJson('/api/blogs');
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     'blogs',
+                     'pagination' => ['current_page', 'per_page', 'total'],
+                 ]);
+
+        $this->assertCount(3, $response->json('blogs'));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests for Email and Password value objects
- cover BlogService behaviors with domain tests
- exercise register/login and blog listing API endpoints
- configure PHPUnit to load domain tests

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `composer install -n --no-progress --prefer-dist` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68adc61b9e60832387a4784880b8b241